### PR TITLE
Don’t install PKGNG on 9 if it already exists

### DIFF
--- a/test/integration/pkgng/serverspec/pkgng_spec.rb
+++ b/test/integration/pkgng/serverspec/pkgng_spec.rb
@@ -17,3 +17,8 @@ describe command('pkg query %n pkg') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should eq("pkg\n") }
 end
+
+describe file('/etc/make.conf') do
+  it { should be_file }
+  it { should contain 'WITH_PKGNG' }
+end


### PR DESCRIPTION
There are instances where the base FreeBSD 9 install will alreadycontain a fully configured `pkg`. The [‘official’ FreeBSD 9 EC2 AMIs](http://www.daemonology.net/freebsd-on-ec2/) follow this pattern.

/cc @opscode-cookbooks/release-engineers @scotthain 
