### PR TITLE
Chef 17 compatibility (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the freebsd cookbook.
 
 ## Unreleased
 
+- Enable unified_mode for Chef 17 compatibility
+- Require Chef 15.3+
 - Remove delivery folder
 
 ## 1.1.2 - *2021-08-30*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 12.15+
+- Chef 15.3+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ description       'Handles FreeBSD ports setup'
 version           '1.1.2'
 source_url        'https://github.com/sous-chefs/freebsd'
 issues_url        'https://github.com/sous-chefs/freebsd/issues'
-chef_version      '>= 12.15'
+chef_version      '>= 15.3'
 
 supports 'freebsd'

--- a/resources/port_options.rb
+++ b/resources/port_options.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+unified_mode true
+
 property :source, String
 property :options, Hash
 property :dir_path, String, default: lazy { |r| '/var/db/ports/' + r.name }


### PR DESCRIPTION
# Description

This PR enables unified_mode so the cookbook passes Chef 17 cookstyle requirements.

## Issues Resolved

List any existing issues this PR resolves

#47 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
