### PR TITLE
ci: pass required slack secrets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
## Problem

Merging #88 produced no release. The release run ended in `startup_failure`, as has every push to `main` since July:

```
2026-08-16  startup_failure  fix: migrate dependency resolution to Policyfile (#88)
2026-08-13  startup_failure  Update actions/stale action to v11 (#87)
2026-07-09  startup_failure  Update sous-chefs/.github action to v9 (#86)
```

`sous-chefs/.github@9.0.0` declares `slack_bot_token` and `slack_channel_id` as `required: true`. This caller does not pass them, so the reusable workflow fails validation and the job never starts — meaning release-please never executes and no release is cut.

## Fix

Pass the two secrets. Both already exist as sous-chefs org secrets with `ALL` repository visibility, so nothing needs creating.

## After merge

release-please should open a release PR covering the commits since `2.0.13`, including the Policyfile migration from #88.